### PR TITLE
IPPET wrapper can store entire interval data. 

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -9,6 +9,7 @@ class Wrapper:
         df = DataFrame(columns=self._fields)
 
         for i in range(0, self._args.iterations):
+            self.current_iteration = i  # allows for proper interval-file naming
             df = self._run_iteration(df)
 
         return self._compute_summary(df)

--- a/wrappers/IPPET.py
+++ b/wrappers/IPPET.py
@@ -27,7 +27,6 @@ class IPPET(Wrapper):
     def __init__(self, args, browser, page):
         super().__init__(args)
 
-        # the browser is used to specify file extension; thus, one word is requisite
         self.browser = browser
         self.page = page
         self._fields = [self._tot_cpu, self._tot_gpu, self._avg_gpu, self._avg_cpu]


### PR DESCRIPTION
Rather than only providing the user with summary information, this patch allows the entire IPPET interval data to be stored in its own directory for further review in addition to the original report.csv file. Also, it wouldn't be too difficult to add similar support for BLA and PowerGadget.
